### PR TITLE
add wait_ready() and cached_block() functions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -114,7 +114,7 @@ toml = "*"
 
 [[package]]
 name = "brewblox-service"
-version = "0.32.3"
+version = "0.33.0"
 description = "Scaffolding for Brewblox backend services"
 category = "main"
 optional = false
@@ -510,7 +510,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4"
-content-hash = "2b90a453cf78cf0bc97057c49ade5253db59761e03157e8bbe61232dec859abe"
+content-hash = "33b6515418630c84ca0db129573111e05fc92e4944d51447ddac7c87e965d9f5"
 
 [metadata.files]
 aiohttp = [
@@ -583,8 +583,8 @@ autopep8 = [
     {file = "autopep8-1.5.5.tar.gz", hash = "sha256:cae4bc0fb616408191af41d062d7ec7ef8679c7f27b068875ca3a9e2878d5443"},
 ]
 brewblox-service = [
-    {file = "brewblox-service-0.32.3.tar.gz", hash = "sha256:46021752cbde3e278332dc2060406dabe91315a81a3ffa99548f27b5d8913d86"},
-    {file = "brewblox_service-0.32.3-py3-none-any.whl", hash = "sha256:d5735c94d95f4265fac5929cad1f65f392c0501a52596e4204eb8411ef947ba9"},
+    {file = "brewblox-service-0.33.0.tar.gz", hash = "sha256:7dbfdf97ae5e63f0410aabb322aff87d98d2195865e9082adb13d8622b4c93ea"},
+    {file = "brewblox_service-0.33.0-py3-none-any.whl", hash = "sha256:d11501e2f50e69f1117f3ede735234d72ad2fea183261e4be30e05fe1bc013fa"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "brewblox-spark-api"
-version = "0.1.1"
+version = "0.2.0"
 description = "Client-side API for consuming Spark blocks"
 authors = ["BrewPi.bv <development@brewpi.com>"]
 license = "GPL-3.0"
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4"
-brewblox-service = ">=0.32"
+brewblox-service = "0.33"
 
 [tool.poetry.dev-dependencies]
 pytest-flake8 = "^1.0.7"


### PR DESCRIPTION
Adds two functions, and removes the default wait from API calls.

`wait_ready(timeout: float)` does what it says on the tin: it waits for the ready event for up to `timeout` seconds.
This was extracted from the API calls to give clients the choice whether to wait, or just handle any errors that may occur.

`cached_block(id: str)` checks `self.blocks` for a block with given ID. If it is not found, it returns None.
This means it will return None if the block does not exist, but also if the service is not yet ready.